### PR TITLE
Update README.md search tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Search tags
 
+* Warning: phpinfo() has been disabled for security reasons
 * phpinfo() is disabled
 * Alternative to phpinfo()
 * Replacement for phpinfo()
-* Warning: phpinfo() has been disabled for security reasons in /home2/site/site.ir/public_html/phpinfo.php on line 1

--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@
 * phpinfo() is disabled
 * Alternative to phpinfo()
 * Replacement for phpinfo()
+* Warning: phpinfo() has been disabled for security reasons in /home2/site/site.ir/public_html/phpinfo.php on line 1


### PR DESCRIPTION
Adding an actual shared hosting error as a search tag:
* Warning: phpinfo() has been disabled for security reasons in /home2/site/site.ir/public_html/phpinfo.php on line 1

I had this error on a shared hosting ( http://WWW.OVH.COM ) and they disabled phpinfo() so i could add the error for the others to find by search engines.
Thank you for your great job. this project of you (https://github.com/jorunkel/softphpinfo) helped me a lot.